### PR TITLE
jotta-cli add would not add directories with spaces

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -128,7 +128,7 @@ done
 
 echo "Adding backups"
 
-for dir in /backup/* ; do if [ -d "${dir}" ]; then set +e && jotta-cli add /$dir && set -e; fi; done
+for dir in /backup/* ; do if [ -d "${dir}" ]; then set +e && jotta-cli add "${dir}" && set -e; fi; done
 
 # load ignore file
 if [ -f /config/ignorefile ]; then


### PR DESCRIPTION
Changed jotta-cli add to "${dir}" so it also handles directories with spaces. This also solves https://github.com/bluet/docker-jottacloud/issues/5 with the extra slash.